### PR TITLE
Di 4525

### DIFF
--- a/RationalOptionPages.php
+++ b/RationalOptionPages.php
@@ -252,7 +252,7 @@ class RationalOptionPages {
 						$params['callback'] = array( $this, $params['callback'] );
 					}
 
-					call_user_func_array( 'add_settings_section', $params );
+					call_user_func_array( 'add_settings_section', array_values ($params) );
 
 					if ( !empty( $section_params['fields'] ) ) {
 						foreach ( $section_params['fields'] as $field_key => $field_params ) {
@@ -279,7 +279,7 @@ class RationalOptionPages {
 								$params['callback'] = array( $this, $params['callback'] );
 							}
 
-							call_user_func_array( 'add_settings_field', $params );
+							call_user_func_array( 'add_settings_field', array_values ($params) );
 						}
 					}
 				}
@@ -302,7 +302,7 @@ class RationalOptionPages {
 			// Finalize callback
 			$params['callback'] = array( $this, $params['callback'] );
 
-			call_user_func_array( $page['function'], $params );
+			call_user_func_array( $page['function'], array_values ($params) );
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nightingale-companion",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nightingale-companion",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "jsdoc": "^3.6.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nightingale-companion",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "GPL-3.0-or-later",
   "main": "nightingale-companion.php",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: Nick-Summerfield, tblacker7
 Tags: theme, nightingale, nhs
 Plugin Name:: Nightingale Companion
 Requires at least: 5.0
-Tested up to: 5.9
-Stable tag: 1.3
+Tested up to: 6.0
+Stable tag: 1.3.1
 Requires PHP: 5.6
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/settings.php
+++ b/settings.php
@@ -4,7 +4,7 @@
  *
  * @package   nightingale-companion
  * @copyright NHS Leadership Academy, Nick Summerfield & Tony Blacker
- * @version   1.3.0 26th June 2020
+ * @version   1.3.1 19 July 2022
  */
 
 /**


### PR DESCRIPTION
This is to make the Plugin compatible with PHP 8. The file RationalOptionPages.php had code that was not suitable for PHP 8 and would cause the site to break.

This file was originally third party, but is used widely in plugin development due to the way WordPress handles option pages.

This PR corresponds to the task DI-4525 which was to stop showing this error. This has solved the problem locally for me, however it will require testing.

Also updating to version 1.3.1 so that the newest code is pushed to wordpress.org.