### PR TITLE
Fix invalid AddToAny link addition criteria.

### DIFF
--- a/display/social-sharing.php
+++ b/display/social-sharing.php
@@ -40,6 +40,8 @@ function nightingale_companion_sharing_caring( $content ) {
 			$content = $content . $output;
 		} elseif ( 'both' === $position ) {
 			$content = $output . $content . $output;
+		} else {
+			$output = false;
 		}
 		if ( ! empty( $output ) ) {
 			$content = $content . '<script async src="https://static.addtoany.com/menu/page.js"></script>';


### PR DESCRIPTION
Currently, the AddToAny javascript reference is added to the output when social sharing function is called and there is a title being set. This commit makes addition of that reference based on if social sharing link is configured to show on the page by resetting the value of `$output` to `false` in case the social sharing widget is not used.