### PR TITLE
DI-6945 Fixed emergency alert when last updated date not set

### DIFF
--- a/display/partials/emergency-alert.php
+++ b/display/partials/emergency-alert.php
@@ -27,7 +27,10 @@
 					<?php
 					if ( ( get_theme_mod( 'emergency_date_on' ) === 'yes' ) && ( get_theme_mod( 'emergency_date' ) !== 'dd/mm/yyyy' ) ) {
 						$date = strtotime( get_theme_mod( 'emergency_date' ) );
-						echo '<p class="nhsuk-global-alert__updated">Last Updated ' . esc_html( date( 'jS F Y', esc_attr( $date ) ) ) . '</p>';
+						if ( empty( $date ) ) {
+							$date = strtotime( gmdate( 'Y-m-d' ) );
+						}
+						echo '<p class="nhsuk-global-alert__updated">Last Updated ' . esc_html( gmdate( 'jS F Y', esc_attr( $date ) ) ) . '</p>';
 					}
 					?>
 				</div>

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,7 @@ with sample content on a site running the Nightingale theme, this plgin and the 
 
  -Fix for floating social icons
  -Security update
+ -Fixed emergency alert when last updated date not set
 
  = 1.3.6 =
 


### PR DESCRIPTION
To replicate this issue, please customise the nightingale theme emergency alert ON, and set YES to **Show last updated?** without specifying a date.

This will break the frontend (php error). Better we give current date if not specified when customisation.